### PR TITLE
Решение ошибки при использовании adapterMode=0

### DIFF
--- a/testit-python-commons/src/testit_python_commons/client/api_client.py
+++ b/testit-python-commons/src/testit_python_commons/client/api_client.py
@@ -47,7 +47,7 @@ class ApiClientWorker:
 
         response = test_run_api.get_test_run_by_id(self.__config.get_test_run_id())
 
-        test_results = response['testResults']
+        test_results = response['_data_store']['test_results']
 
         return Utils.autotests_parser(
             test_results,

--- a/testit-python-commons/src/testit_python_commons/services/utils.py
+++ b/testit-python-commons/src/testit_python_commons/services/utils.py
@@ -18,8 +18,8 @@ class Utils:
         resolved_autotests = []
 
         for data_autotest in data_autotests:
-            if configuration == data_autotest['configurationId']:
-                resolved_autotests.append(data_autotest['autoTest']['externalId'])
+            if configuration == data_autotest['_data_store']['configuration_id']:
+                resolved_autotests.append(data_autotest._data_store['auto_test']._data_store['external_id'])
 
         return resolved_autotests
 


### PR DESCRIPTION
Решение проблемы запуска АТ из UI TestIT через интерфейса тест-плана:
Части трейсов ошибок
- testit_api_client.exceptions.ApiAttributeError: TestRunV2GetModel has no attribute 'testResults' at ['['received_data']']['testResults']
- testit_api_client.exceptions.ApiAttributeError: TestResultV2GetModel has no attribute 'configurationId' at ['['received_data', 'test_results', 0]']['configurationId']

Версия API Client 2.0, Test IT 3.5