### PR TITLE
Fixed work with byte arrays

### DIFF
--- a/testit-python-commons/src/testit_python_commons/dynamic_methods.py
+++ b/testit-python-commons/src/testit_python_commons/dynamic_methods.py
@@ -84,7 +84,7 @@ def addAttachments(data, is_text: bool = False, name: str = None):   # noqa: N80
 @adapter_logger
 def add_attachments_to_step(step, data, is_text: bool = False, name: str = None):
     if is_text:
-        attachment_ids = TmsPluginManager.get_adapter_manager().create_attachment(str(data), name)
+        attachment_ids = TmsPluginManager.get_adapter_manager().create_attachment(data, name)
     else:
         if isinstance(data, str):
             attachment_ids = TmsPluginManager.get_adapter_manager().load_attachments([data])
@@ -102,7 +102,7 @@ def add_attachments_to_test(data, is_text: bool = False, name: str = None):
     if is_text and hasattr(TmsPluginManager.get_plugin_manager().hook, 'create_attachment'):
         TmsPluginManager.get_plugin_manager().hook \
             .create_attachment(
-            body=str(data),
+            body=data,
             name=name)
     elif hasattr(TmsPluginManager.get_plugin_manager().hook, 'add_attachments'):
         if isinstance(data, str):

--- a/testit-python-commons/src/testit_python_commons/services/adapter_manager.py
+++ b/testit-python-commons/src/testit_python_commons/services/adapter_manager.py
@@ -54,14 +54,14 @@ class AdapterManager:
         return self.__api_client.load_attachments(attach_paths)
 
     @adapter_logger
-    def create_attachment(self, body: str, name: str):
+    def create_attachment(self, body: str | bytes, name: str):
         if name is None:
             name = str(uuid.uuid4()) + '-attachment.txt'
 
         path = os.path.join(os.path.abspath(''), name)
 
         with open(path, 'wb') as attached_file:
-            attached_file.write(body.encode('utf-8'))
+            attached_file.write(body.encode('utf-8') if isinstance(body, str) else body)
 
         attachment_id = self.__api_client.load_attachments((path,))
 


### PR DESCRIPTION
I encountered a problem with sending screenshots taken by Selenium WebDriver. The get_screenshot_as_png() method returns a base64 byte array, but testit_pytest_adapter converts the bytes into a string using the str(data) function. This breaks the file saving as a PNG. The fix I published allows screenshots to be sent in the following way:
`screenshot = browser.get_screenshot_as_png()`
`addAttachments(screenshot, is_text=True, name="error_screen.png")`