### PR TITLE
TMS-27005: fix self present in step parameters

### DIFF
--- a/testit-adapter-nose/setup.py
+++ b/testit-adapter-nose/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='testit-adapter-nose',
-    version='3.2.5',
+    version='3.2.6',
     description='Nose adapter for Test IT',
     long_description=open('README.md', "r").read(),
     long_description_content_type="text/markdown",
@@ -23,7 +23,7 @@ setup(
     py_modules=['testit_adapter_nose'],
     packages=find_packages(where='src'),
     package_dir={'': 'src'},
-    install_requires=['attrs', 'nose2', 'testit-python-commons==3.2.5'],
+    install_requires=['attrs', 'nose2', 'testit-python-commons==3.2.6'],
     entry_points={
             'nose.plugins.0.10': [
                 'testit_adapter_nose = testit_adapter_nose.plugin:TmsPlugin',

--- a/testit-adapter-pytest/setup.py
+++ b/testit-adapter-pytest/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='testit-adapter-pytest',
-    version='3.2.5',
+    version='3.2.6',
     description='Pytest adapter for Test IT',
     long_description=open('README.md', "r").read(),
     long_description_content_type="text/markdown",
@@ -21,6 +21,6 @@ setup(
     py_modules=['testit_adapter_pytest'],
     packages=find_packages(where='src'),
     package_dir={'': 'src'},
-    install_requires=['pytest', 'pytest-xdist', 'attrs', 'testit-python-commons==3.2.5'],
+    install_requires=['pytest', 'pytest-xdist', 'attrs', 'testit-python-commons==3.2.6'],
     entry_points={'pytest11': ['testit_adapter_pytest = testit_adapter_pytest.plugin']}
 )

--- a/testit-adapter-robotframework/setup.py
+++ b/testit-adapter-robotframework/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='testit-adapter-robotframework',
-    version='3.2.5',
+    version='3.2.6',
     description='Robot Framework adapter for Test IT',
     long_description=open('README.md', "r").read(),
     long_description_content_type="text/markdown",
@@ -23,5 +23,5 @@ setup(
     py_modules=['testit_adapter_robotframework'],
     packages=find_packages(where='src'),
     package_dir={'': 'src'},
-    install_requires=['attrs', 'robotframework', 'testit-python-commons==3.2.5']
+    install_requires=['attrs', 'robotframework', 'testit-python-commons==3.2.6']
 )

--- a/testit-python-commons/setup.py
+++ b/testit-python-commons/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='testit-python-commons',
-    version='3.2.5',
+    version='3.2.6',
     description='Python commons for Test IT',
     long_description=open('README.md', "r").read(),
     long_description_content_type="text/markdown",

--- a/testit-python-commons/src/testit_python_commons/services/utils.py
+++ b/testit-python-commons/src/testit_python_commons/services/utils.py
@@ -70,6 +70,12 @@ class Utils:
         return parameters
 
     @staticmethod
+    def exclude_self_parameter(all_parameters: dict) -> dict:
+        if all_parameters.get('self') is not None:
+            all_parameters.pop('self')
+        return all_parameters
+
+    @staticmethod
     def collect_parameters_in_string_attribute(attribute: str, all_parameters: dict) -> str:
         param_keys = []
 

--- a/testit-python-commons/src/testit_python_commons/step.py
+++ b/testit-python-commons/src/testit_python_commons/step.py
@@ -61,7 +61,9 @@ class StepContext:
         self.__step_result\
             .set_title(self.__title)\
             .set_description(self.__description)\
-            .set_parameters(self.__parameters)
+            .set_parameters(
+                Utils.exclude_self_parameter(self.__parameters)
+            )
 
         logging.debug(f'Step "{self.__title}" was started')
 


### PR DESCRIPTION
Fixing bug with 'self' presentation as step's parameters in TMS.

![image](https://github.com/user-attachments/assets/ce8144b5-610c-4113-88ff-df0bddaa11b1)

How to reproduce (pytest --testit): 


```python
class TestClass:
    @testit.step("Step03 Title")
    def step03(self):
        pass

    @testit.step("Step04 {number} Title")
    def step04(self, number: int):
        pass

    def test_with_steps_with_title_annotation_success(self):
        self.step03()
        self.step04(3)
        assert True
```