### PR TITLE
fix: Add pyproject.toml handling

### DIFF
--- a/testit-adapter-behave/README.md
+++ b/testit-adapter-behave/README.md
@@ -33,11 +33,11 @@ pip install testit-adapter-behave
 | Mode of automatic updation links to test cases (**It's optional**). Default value - false. The adapter supports following modes:<br/>true - in this mode, the adapter will update links to test cases<br/>false - in this mode, the adapter will not update link to test cases                                                                                                         | automaticUpdationLinksToTestCases | TMS_AUTOMATIC_UPDATION_LINKS_TO_TEST_CASES | tmsAutomaticUpdationLinksToTestCases |
 | Mode of import type selection when launching autotests (**It's optional**). Default value - true. The adapter supports following modes:<br/>true - in this mode, the adapter will create/update each autotest in real time<br/>false - in this mode, the adapter will create/update multiple autotests                                                                                 | importRealtime                    | TMS_IMPORT_REALTIME                        | tmsImportRealtime                    |
 | Url of proxy server (**It's optional**)                                                                                                                                                                                                                                                                                                                                                | tmsProxy                          | TMS_PROXY                                  | tmsProxy                             |
-| Name of the configuration file If it is not provided, it is used default file name (**It's optional**)                                                                                                                                                                                                                                                                                 | -                                 | TMS_CONFIG_FILE                            | tmsConfigFile                        |
+| Name (**including extension**) of the configuration file If it is not provided, it is used default file name (**It's optional**)                                                                                                                                                                                                                                                       | -                                 | TMS_CONFIG_FILE                            | tmsConfigFile                        |
 
 #### File
 
-Create **connection_config.ini** file in the root directory of the project:
+Add `[testit]` block to your **pyproject.toml** or create **connection_config.ini** file in the root directory of the project:
 ```
 [testit]
 URL = URL
@@ -59,7 +59,7 @@ tmsProxy = TMS_PROXY
 
 #### Examples
 
-Launch with a connection_config.ini file in the root directory of the project:
+Launch with a `pyproject.toml` or `connection_config.ini` file in the root directory of the project:
 
 ```
 $ behave -f testit_adapter_behave.formatter:AdapterFormatter

--- a/testit-adapter-nose/README.md
+++ b/testit-adapter-nose/README.md
@@ -33,11 +33,11 @@ pip install testit-adapter-nose
 | Mode of automatic updation links to test cases (**It's optional**). Default value - false. The adapter supports following modes:<br/>true - in this mode, the adapter will update links to test cases<br/>false - in this mode, the adapter will not update link to test cases                                                                                                         | automaticUpdationLinksToTestCases | TMS_AUTOMATIC_UPDATION_LINKS_TO_TEST_CASES |
 | Mode of import type selection when launching autotests (**It's optional**). Default value - true. The adapter supports following modes:<br/>true - in this mode, the adapter will create/update each autotest in real time<br/>false - in this mode, the adapter will create/update multiple autotests                                                                                 | importRealtime                    | TMS_IMPORT_REALTIME                        |
 | Url of proxy server (**It's optional**)                                                                                                                                                                                                                                                                                                                                                | tmsProxy                          | TMS_PROXY                                  |
-| Name of the configuration file If it is not provided, it is used default file name (**It's optional**)                                                                                                                                                                                                                                                                                 | -                                 | TMS_CONFIG_FILE                            |
+| Name (**including extension**) of the configuration file If it is not provided, it is used default file name (**It's optional**)                                                                                                                                                                                                                                                       | -                                 | TMS_CONFIG_FILE                            | tmsConfigFile                        |
 
 #### File
 
-Create **connection_config.ini** file in the root directory of the project:
+Add `[testit]` block to your **pyproject.toml** or create **connection_config.ini** file in the root directory of the project:
 ```
 [testit]
 URL = URL
@@ -59,7 +59,7 @@ tmsProxy = TMS_PROXY
 
 #### Examples
 
-Launch with a connection_config.ini file in the root directory of the project:
+Launch with a `pyproject.toml` or `connection_config.ini` file in the root directory of the project:
 
 ```
 $ nose2 --testit

--- a/testit-adapter-pytest/README.md
+++ b/testit-adapter-pytest/README.md
@@ -33,11 +33,11 @@ pip install testit-adapter-pytest
 | Mode of automatic updation links to test cases (**It's optional**). Default value - false. The adapter supports following modes:<br/>true - in this mode, the adapter will update links to test cases<br/>false - in this mode, the adapter will not update link to test cases                                                                                                         | automaticUpdationLinksToTestCases | TMS_AUTOMATIC_UPDATION_LINKS_TO_TEST_CASES | tmsAutomaticUpdationLinksToTestCases |
 | Mode of import type selection when launching autotests (**It's optional**). Default value - true. The adapter supports following modes:<br/>true - in this mode, the adapter will create/update each autotest in real time<br/>false - in this mode, the adapter will create/update multiple autotests                                                                                 | importRealtime                    | TMS_IMPORT_REALTIME                        | tmsImportRealtime                    |
 | Url of proxy server (**It's optional**)                                                                                                                                                                                                                                                                                                                                                | tmsProxy                          | TMS_PROXY                                  | tmsProxy                             |
-| Name of the configuration file If it is not provided, it is used default file name (**It's optional**)                                                                                                                                                                                                                                                                                 | -                                 | TMS_CONFIG_FILE                            | tmsConfigFile                        |
+| Name (**including extension**) of the configuration file If it is not provided, it is used default file name (**It's optional**)                                                                                                                                                                                                                                                       | -                                 | TMS_CONFIG_FILE                            | tmsConfigFile                        |
 
 #### File
 
-Create **connection_config.ini** file in the root directory of the project:
+Add `[testit]` block to your **pyproject.toml** or create **connection_config.ini** file in the root directory of the project:
 ```
 [testit]
 URL = URL
@@ -59,7 +59,7 @@ tmsProxy = TMS_PROXY
 
 #### Examples
 
-Launch with a connection_config.ini file in the root directory of the project:
+Launch with a `pyproject.toml` or `connection_config.ini` file in the root directory of the project:
 
 ```
 $ pytest --testit

--- a/testit-adapter-robotframework/README.md
+++ b/testit-adapter-robotframework/README.md
@@ -31,11 +31,11 @@ pip install testit-adapter-robotframework
 | Mode of automatic updation links to test cases (**It's optional**). Default value - false. The adapter supports following modes:<br/>true - in this mode, the adapter will update links to test cases<br/>false - in this mode, the adapter will not update link to test cases                                                                                                         | automaticUpdationLinksToTestCases | TMS_AUTOMATIC_UPDATION_LINKS_TO_TEST_CASES | tmsAutomaticUpdationLinksToTestCases |
 | Mode of import type selection when launching autotests (**It's optional**). Default value - true. The adapter supports following modes:<br/>true - in this mode, the adapter will create/update each autotest in real time<br/>false - in this mode, the adapter will create/update multiple autotests                                                                                 | importRealtime                    | TMS_IMPORT_REALTIME                        | tmsImportRealtime                    |
 | Url of proxy server (**It's optional**)                                                                                                                                                                                                                                                                                                                                                | tmsProxy                          | TMS_PROXY                                  | tmsProxy                             |
-| Name of the configuration file If it is not provided, it is used default file name (**It's optional**)                                                                                                                                                                                                                                                                                 | -                                 | TMS_CONFIG_FILE                            | tmsConfigFile                        |
+| Name (**including extension**) of the configuration file If it is not provided, it is used default file name (**It's optional**)                                                                                                                                                                                                                                                       | -                                 | TMS_CONFIG_FILE                            | tmsConfigFile                        |
 
 #### File
 
-Create **connection_config.ini** file in the root directory of the project:
+Add `[testit]` block to your **pyproject.toml** or create **connection_config.ini** file in the root directory of the project:
 ```
 [testit]
 URL = URL
@@ -57,7 +57,7 @@ tmsProxy = TMS_PROXY
 
 #### Examples
 
-Launch with a connection_config.ini file in the root directory of the project:
+Launch with a `pyproject.toml` or `connection_config.ini` file in the root directory of the project:
 
 ```
 $ robot -v testit TEST_DIRECTORY

--- a/testit-python-commons/src/testit_python_commons/app_properties.py
+++ b/testit-python-commons/src/testit_python_commons/app_properties.py
@@ -12,7 +12,7 @@ from testit_python_commons.models.adapter_mode import AdapterMode
 class AppProperties:
     __project_metadata_file = 'pyproject.toml'
     __properties_file = 'connection_config.ini'
-    __available_extensions = [".ini", ".toml"]
+    __available_extensions = ['.ini', '.toml']
 
     __env_prefix = 'TMS'
 
@@ -41,7 +41,7 @@ class AppProperties:
             _, extension = os.path.splitext(file_name)
             if extension not in cls.__available_extensions:
                 raise FileNotFoundError(
-                    f"{file_name} is not a valid file. Available extensions: {cls.__available_extensions}"
+                    f'{file_name} is not a valid file. Available extensions: {cls.__available_extensions}'
                 )
             cls.__properties_file = file_name
 

--- a/testit-python-commons/src/testit_python_commons/app_properties.py
+++ b/testit-python-commons/src/testit_python_commons/app_properties.py
@@ -10,7 +10,10 @@ from testit_python_commons.models.adapter_mode import AdapterMode
 
 
 class AppProperties:
-    __properties_file = 'connection_config'
+    __project_metadata_file = 'pyproject.toml'
+    __properties_file = 'connection_config.ini'
+    __available_extensions = [".ini", ".toml"]
+
     __env_prefix = 'TMS'
 
     @staticmethod
@@ -35,16 +38,25 @@ class AppProperties:
         root = path[:path.index(os.sep)]
 
         if file_name:
+            _, extension = os.path.splitext(file_name)
+            if extension not in cls.__available_extensions:
+                raise FileNotFoundError(
+                    f"{file_name} is not a valid file. Available extensions: {cls.__available_extensions}"
+                )
             cls.__properties_file = file_name
 
         if os.environ.get(f'{cls.__env_prefix}_CONFIG_FILE'):
             cls.__properties_file = os.environ.get(f'{cls.__env_prefix}_CONFIG_FILE')
 
+        if os.path.isfile(cls.__project_metadata_file):
+            # https://peps.python.org/pep-0621/
+            cls.__properties_file = cls.__project_metadata_file
+
         while not os.path.isfile(
-                path + os.sep + f'{cls.__properties_file}.ini') and path != root:
+                path + os.sep + cls.__properties_file) and path != root:
             path = path[:path.rindex(os.sep)]
 
-        path = path + os.sep + f'{cls.__properties_file}.ini'
+        path = path + os.sep + cls.__properties_file
 
         if os.path.isfile(path):
             parser = configparser.RawConfigParser()


### PR DESCRIPTION
- Added `pyproject.toml` as a default location for a testIt configuration variables
- Added configuration file extension checking

Resolves #172 